### PR TITLE
Integrate Load-Balanced WebClient in OrderService for Inventory Servi…

### DIFF
--- a/src/main/java/org/example/orderservice/config/WebClientConfig.java
+++ b/src/main/java/org/example/orderservice/config/WebClientConfig.java
@@ -1,5 +1,6 @@
 package org.example.orderservice.config;
 
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -7,7 +8,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class WebClientConfig {
   @Bean
-  public WebClient webClient() {
-    return WebClient.builder().build();
+  @LoadBalanced
+  public WebClient.Builder webClientBuilder() {
+    return WebClient.builder();
   }
 }

--- a/src/main/java/org/example/orderservice/service/OrderService.java
+++ b/src/main/java/org/example/orderservice/service/OrderService.java
@@ -21,12 +21,11 @@ import java.util.UUID;
 public class OrderService {
   private final OrderRepository orderRepository;
 
-  private final WebClient webClient;
+  private final WebClient.Builder webClientBuilder;
 
-  @Autowired
-  public OrderService(OrderRepository orderRepository, WebClient webClient) {
+  public OrderService(OrderRepository orderRepository, WebClient.Builder webClientBuilder) {
     this.orderRepository = orderRepository;
-    this.webClient = webClient;
+    this.webClientBuilder = webClientBuilder;
   }
 
   public String placeOrder(OrderRequest orderRequest) {
@@ -43,9 +42,10 @@ public class OrderService {
             .toList();
 
     // Call inventory-service to check if item is in stock
-    InventoryResponse[] inventoryResponseList = webClient
+    InventoryResponse[] inventoryResponseList = webClientBuilder
+            .build()
             .get()
-            .uri("http://localhost:8082/api/inventory",
+            .uri("http://inventory-service/api/inventory",
                     uriBuilder -> uriBuilder.queryParam("skuCodeList", skuCodeList)
                             .build())
             .retrieve()


### PR DESCRIPTION
### Description:
This pull request introduces the following changes to the codebase:

- Added `@LoadBalanced` annotation to the `WebClient.Builder` bean in `WebClientConfig`.
- Modified `OrderService` to use `WebClient.Builder` instead of a pre-built `WebClient`.
- Updated the URI for calling the inventory service to use the service name `inventory-service` instead of a hardcoded URL.

### Purpose:
The purpose of this pull request is to enhance the communication between the Order Service and the Inventory Service by introducing load-balanced WebClient configuration. This ensures better scalability and flexibility in handling service endpoints.
