### PR TITLE
Add Kafka Producer for Order Notification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing-bridge-brave</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/example/orderservice/config/KafkaConfig.java
+++ b/src/main/java/org/example/orderservice/config/KafkaConfig.java
@@ -1,0 +1,16 @@
+package org.example.orderservice.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaConfig {
+  @Bean
+  public NewTopic notificationTopic() {
+    return TopicBuilder
+            .name("notificationTopic")
+            .build();
+  }
+}

--- a/src/main/java/org/example/orderservice/event/OrderNotification.java
+++ b/src/main/java/org/example/orderservice/event/OrderNotification.java
@@ -1,0 +1,12 @@
+package org.example.orderservice.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderNotification {
+  private String orderNumber;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,3 +29,8 @@ resilience4j.circuitbreaker.instances.inventory.automaticTransitionFromOpenToHal
 
 # Zipkin Configuration
 management.tracing.sampling.probability=1.0
+
+# Kafka Properties
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION
### Description:
This pull request introduces the integration of Apache Kafka into the Order Service application for publishing order notification events.

### Changes:
- **Add Kafka Dependency:** Added `spring-kafka` dependency to `pom.xml`.
- **Define Kafka Topic:** Created `KafkaConfig` class to define a `NewTopic` bean for `notificationTopic`.
- **Create OrderNotification Class:** Created `OrderNotification` class to encapsulate order number.
- **Update OrderService:** Updated `OrderService` to send `OrderNotification` to `notificationTopic` using `KafkaTemplate` after order creation.
- **Add Kafka Producer Properties:** Added Kafka producer properties in `application.properties`.

### Purpose:
The purpose of this pull request is to enable the Order Service to publish order notification events to the `notificationTopic` Kafka topic. After an order is successfully created, an `OrderNotification` object containing the order number is sent to the Kafka topic using the `KafkaTemplate`. This allows other services or consumers to subscribe to this topic and receive order notifications for further processing, such as sending notifications to customers or triggering additional workflows.