### PR TITLE
Refactor Properties Configuration for Local Environment

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,3 +1,16 @@
+# Eureka Server URL
+eureka.client.service-url.default-zone=http://root:root@localhost:8761/eureka
+
+# PostgreSQL Database Connection
 spring.datasource.url=jdbc:postgresql://localhost:5432/order
 spring.datasource.username=postgres
 spring.datasource.password=root
+
+# Zipkin Configuration
+management.zipkin.tracing.endpoint=http://localhost:9411/api/v2/spans
+management.tracing.sampling.probability=1.0
+
+# Kafka Properties
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,17 @@
 spring.profiles.active=local
 
+server.port=0
+
+spring.application.name=order-service
+
+# JPA Properties
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.ddl-auto=create
+
+# Logging level
 logging.level.org.hibernate.SQL=debug
-server.port=0
-
-# Eureka Server URL
-eureka.client.service-url.default-zone=http://root:root@localhost:8761/eureka
-
-spring.application.name=order-service
 
 # Actuator Properties
 management.health.circuitbreakers.enabled=true
@@ -26,11 +27,3 @@ resilience4j.circuitbreaker.instances.inventory.failureRateThreshold=50
 resilience4j.circuitbreaker.instances.inventory.waitDurationInOpenState=5s
 resilience4j.circuitbreaker.instances.inventory.permittedNumberOfCallsInHalfOpenState=3
 resilience4j.circuitbreaker.instances.inventory.automaticTransitionFromOpenToHalfOpenEnabled=true
-
-# Zipkin Configuration
-management.tracing.sampling.probability=1.0
-
-# Kafka Properties
-spring.kafka.bootstrap-servers=localhost:9092
-spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
-spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
### Description:
This pull request introduces changes to refactor the properties configuration for the Order Service by separating environment-specific configurations from the global configurations.

### Changes:
- **Refactor Properties Configuration for Local Environment:**
   - Moved Eureka server URL configuration from `application.properties` to `application-local.properties`
   - Moved PostgreSQL database connection properties from `application.properties` to `application-local.properties`
   - Added Zipkin configuration to `application-local.properties`
   - Added Kafka properties to `application-local.properties`
   - Moved `spring.application.name` and `server.port` properties to `application.properties`
   - Moved JPA and Resilience4j properties to `application.properties`
   - Removed Eureka, Zipkin, and Kafka properties from `application.properties`

### Purpose:
The purpose of this pull request is to refactor the properties configuration for the Order Service by separating environment-specific configurations from the global configurations. The Eureka server URL, PostgreSQL database connection, Zipkin, and Kafka properties have been moved to the `application-local.properties` file, while the global properties like `spring.application.name`, `server.port`, JPA, and Resilience4j configurations remain in the `application.properties` file. This separation promotes better organization and maintainability of the application configuration.